### PR TITLE
Poolboy, cache, and maps returned

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,5 +2,6 @@
 {deps, [
   {hackney, ".*", {git, "git://github.com/benoitc/hackney.git", {branch, "master"}}},
   {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {branch, "master"}}},
-  {meck, ".*", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.3"}}}
+  {meck, ".*", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.3"}}},
+  {poolboy, ".*", {git, "git://github.com/devinus/poolboy.git", {branch, "master"}}}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -13,4 +13,8 @@
        {ref,"17b0ea5b7d9c93af3a52b5152c6bee14302b3885"}},
   0},
  {<<"mimerl">>,{pkg,<<"mimerl">>,<<"1.0.0">>},1},
+ {<<"poolboy">>,
+  {git,"git@github.com:devinus/poolboy.git",
+       {ref,"d378f996182daa6251ad5438cee4d3f6eb7ea50f"}},
+  0},
  {<<"ssl_verify_hostname">>,{pkg,<<"ssl_verify_hostname">>,<<"1.0.5">>},1}].

--- a/src/virustotal_client.erl
+++ b/src/virustotal_client.erl
@@ -81,7 +81,7 @@ do_post(Url, ReqBody) ->
   case StatusCode of
     200 ->
       {ok, Body} = hackney:body(ClientRef),
-      Decoded = jsx:decode(Body, [{labels, atom}]),
+      Decoded = jsx:decode(Body, [{labels, atom}, return_maps]),
       {ok, Decoded};
     403 ->
       {error, permission_denied};

--- a/src/virustotal_sup.erl
+++ b/src/virustotal_sup.erl
@@ -15,6 +15,7 @@
 -export([init/1]).
 
 -define(SERVER, ?MODULE).
+-define(CACHE_NAME, virustotal).
 
 %%====================================================================
 %% API
@@ -44,4 +45,5 @@ init([]) ->
                intensity => 5,
                period => 10},
   ChildSpecs = [],
+  ets:new(?CACHE_NAME, [set, named_table, public]),
   {ok, {SupFlags, ChildSpecs}}.

--- a/test/virustotal_client_tests.erl
+++ b/test/virustotal_client_tests.erl
@@ -1,0 +1,251 @@
+-module(virustotal_client_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(setup(F), {setup, fun start/0, fun stop/1, F}).
+
+-define(CACHE_NAME, virustotal).
+
+start() ->
+  application:ensure_all_started(virustotal),
+  {ok, _Pid} = virustotal:start(foo, <<"apikey">>),
+  meck:new(hackney, [passthrough]),
+  foo.
+
+stop(Name) ->
+  meck:unload(hackney),
+  virustotal:stop(Name).
+
+file_report_cache_retrieve_test_() ->
+  [{"file_report checks cache before attempting api call", ?setup(fun results_from_file_report_cache_retrieve/1)}].
+
+file_report_cache_add_test_() ->
+  [{"file_report adds cache result after api call", ?setup(fun results_from_file_report_cache_addition/1)}].
+
+url_report_cache_retrieve_test_() ->
+  [{"url_report checks cache before attempting api call", ?setup(fun results_from_url_report_cache_retrieve/1)}].
+
+url_report_cache_add_test_() ->
+  [{"url_report adds cache result after api call", ?setup(fun results_from_url_report_cache_addition/1)}].
+
+
+results_from_file_report_cache_retrieve(Name) ->
+  load_cache(),
+  Result = {ok,[
+    {scans,[
+      {'Bkav',[{detected,false},
+        {version,<<"1.3.0.8455">>},
+        {result,null},
+        {update,<<"20161013">>}]},
+      {'MicroWorld-eScan',[{detected,true},
+        {version,<<"12.0.250.0">>},
+        {result,<<"Generic.Malware.V!w.7232B058">>},
+        {update,<<"20161013">>}]}]},
+    {scan_id,<<"mockfilereportscanid">>},
+    {sha1,<<"sha1hash">>},
+    {resource,<<"testhash">>},
+    {response_code,1},
+    {scan_date,<<"2016-10-13 22:35:18">>},
+    {permalink,<<"https://www.virustotal.com/file/testhash">>},
+    {verbose_msg,<<"Scan finished, information embedded">>},
+    {total,56},
+    {positives,50},
+    {sha256,<<"sha256hash">>},
+    {md5,<<"md5hash">>}]},
+  ?_assert(Result == virustotal_client:file_report(Name, <<"testhash">>)).
+
+results_from_file_report_cache_addition(Name) ->
+  meck_hackney_file_report(),
+  ?_assert([] == ets:lookup(?CACHE_NAME, {resource, <<"newhash">>})),
+  virustotal_client:file_report(Name, <<"newhash">>),
+  Result = [
+    {{resource, <<"newhash">>},
+      {ok,[
+      {scans,[
+        {'Bkav',[{detected,false},
+          {version,<<"1.3.0.8455">>},
+          {result,null},
+          {update,<<"20161013">>}]},
+        {'MicroWorld-eScan',[{detected,true},
+          {version,<<"12.0.250.0">>},
+          {result,<<"Generic.Malware.V!w.7232B058">>},
+          {update,<<"20161013">>}]}]},
+      {scan_id,<<"mockfilereportscanid">>},
+      {sha1,<<"sha1hash">>},
+      {resource,<<"testhash">>},
+      {response_code,1},
+      {scan_date,<<"2016-10-13 22:35:18">>},
+      {permalink,<<"https://www.virustotal.com/file/testhash">>},
+      {verbose_msg,<<"Scan finished, information embedded">>},
+      {total,56},
+      {positives,50},
+      {sha256,<<"sha256hash">>},
+      {md5,<<"md5hash">>}]}}],
+  ?_assert(Result == ets:lookup(?CACHE_NAME, {resource, <<"newhash">>})).
+
+
+results_from_url_report_cache_retrieve(Name) ->
+  load_cache(),
+  Result = {ok,[
+    {scan_id, <<"mockurlreportscanid">>},
+    {resource,<<"http://www.google.com">>},
+    {url,<<"http://www.google.com/">>},
+    {response_code,1},
+    {scan_date,<<"2016-10-14 22:28:00">>},
+    {permalink,
+      <<"https://www.virustotal.com/url/dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf/analysis/1476484080/">>},
+    {verbose_msg,
+      <<"Scan finished, scan information embedded in this object">>},
+    {filescan_id,null},
+    {positives,0},
+    {total,68},
+    {scans, [
+      {'CLEAN MX',[{detected,false},{result,<<"clean site">>}]},
+      {'Rising',[{detected,false},{result,<<"clean site">>}]},
+      {'AegisLab WebGuard',[{detected,false},{result,<<"clean site">>}]},
+      {'MalwareDomainList', [
+        {detected,false},
+        {result,<<"clean site">>},
+        {detail, <<"http://www.malwaredomainlist.com/mdl.php?search=www.google.com">>}]}]}]},
+  ?_assert(Result == virustotal_client:url_report(Name, <<"http://www.google.com">>)).
+
+results_from_url_report_cache_addition(Name) ->
+  meck_hackney_url_report(),
+  ?_assert([] == ets:lookup(?CACHE_NAME, {resource, <<"newlink">>})),
+  virustotal_client:url_report(Name, <<"newlink">>),
+  Result = [
+    {{resource, <<"newlink">>},
+      {ok,[
+        {scan_id, <<"mockurlreportscanid">>},
+        {resource,<<"http://www.google.com">>},
+        {url,<<"http://www.google.com/">>},
+        {response_code,1},
+        {scan_date,<<"2016-10-14 22:28:00">>},
+        {permalink,
+          <<"https://www.virustotal.com/url/dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf/analysis/1476484080/">>},
+        {verbose_msg,
+          <<"Scan finished, scan information embedded in this object">>},
+        {filescan_id,null},
+        {positives,0},
+        {total,68},
+        {scans, [
+          {'CLEAN MX',[{detected,false},{result,<<"clean site">>}]},
+          {'Rising',[{detected,false},{result,<<"clean site">>}]},
+          {'AegisLab WebGuard',[{detected,false},{result,<<"clean site">>}]},
+          {'MalwareDomainList', [
+            {detected,false},
+            {result,<<"clean site">>},
+            {detail, <<"http://www.malwaredomainlist.com/mdl.php?search=www.google.com">>}]}]}]}}],
+  ?_assert(Result == ets:lookup(?CACHE_NAME, {resource, <<"newlink">>})).
+
+load_cache() ->
+  ets:insert(virustotal, {{resource, <<"testhash">>}, mock_file_report()}),
+  ets:insert(virustotal, {{resource, <<"http://www.google.com">>}, mock_url_report()}).
+
+meck_hackney_file_report() ->
+  meck:expect(hackney, request,
+    fun(_Method, _URL, _Headers, _Payload, _Options) ->
+      {ok, 200, "RespHeaders", "ClientRef"}
+    end),
+  meck:expect(hackney, body,
+    fun("ClientRef") ->
+      {ok, <<"{\"scans\":"
+        "{\"Bkav\":{\"detected\":false,"
+            "\"version\":\"1.3.0.8455\","
+            "\"result\":null,"
+            "\"update\":\"20161013\"},"
+          "\"MicroWorld-eScan\":{\"detected\":true,"
+            "\"version\":\"12.0.250.0\","
+            "\"result\":\"Generic.Malware.V!w.7232B058\","
+            "\"update\":\"20161013\"}},"
+        "\"scan_id\":\"mockfilereportscanid\","
+        "\"sha1\":\"sha1hash\","
+        "\"resource\":\"testhash\","
+        "\"response_code\":1,"
+        "\"scan_date\":\"2016-10-13 22:35:18\","
+        "\"permalink\":\"https://www.virustotal.com/file/testhash\","
+        "\"verbose_msg\":\"Scan finished, information embedded\","
+        "\"total\":56,"
+        "\"positives\":50,"
+        "\"sha256\":\"sha256hash\","
+        "\"md5\":\"md5hash\"}">>}
+    end).
+
+meck_hackney_url_report() ->
+  meck:expect(hackney, request,
+    fun(_Method, _URL, _Headers, _Payload, _Options) ->
+      {ok, 200, "RespHeaders", "ClientRef"}
+    end),
+  meck:expect(hackney, body,
+    fun("ClientRef") ->
+      {ok, <<"{\"scan_id\":\"mockurlreportscanid\","
+        "\"resource\":\"http://www.google.com\","
+        "\"url\":\"http://www.google.com/\","
+        "\"response_code\":1,"
+        "\"scan_date\":\"2016-10-14 22:28:00\","
+        "\"permalink\":\"https://www.virustotal.com/url/dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf/analysis/1476484080/\","
+        "\"verbose_msg\":\"Scan finished, scan information embedded in this object\","
+        "\"filescan_id\":null,"
+        "\"positives\":0,"
+        "\"total\":68,"
+        "\"scans\":"
+          "{\"CLEAN MX\":{"
+              "\"detected\":false,"
+              "\"result\":\"clean site\"},"
+            "\"Rising\":{"
+              "\"detected\":false,"
+              "\"result\":\"clean site\"},"
+            "\"AegisLab WebGuard\":{"
+              "\"detected\":false,"
+              "\"result\":\"clean site\"},"
+            "\"MalwareDomainList\":{"
+              "\"detected\":false,"
+              "\"result\":\"clean site\","
+              "\"detail\":\"http://www.malwaredomainlist.com/mdl.php?search=www.google.com\"}}}">>}
+    end).
+
+mock_file_report() ->
+  {ok,[
+    {scans,[
+      {'Bkav',[{detected,false},
+        {version,<<"1.3.0.8455">>},
+        {result,null},
+        {update,<<"20161013">>}]},
+      {'MicroWorld-eScan',[{detected,true},
+        {version,<<"12.0.250.0">>},
+        {result,<<"Generic.Malware.V!w.7232B058">>},
+        {update,<<"20161013">>}]}]},
+    {scan_id,<<"mockfilereportscanid">>},
+    {sha1,<<"sha1hash">>},
+    {resource,<<"testhash">>},
+    {response_code,1},
+    {scan_date,<<"2016-10-13 22:35:18">>},
+    {permalink,<<"https://www.virustotal.com/file/testhash">>},
+    {verbose_msg,<<"Scan finished, information embedded">>},
+    {total,56},
+    {positives,50},
+    {sha256,<<"sha256hash">>},
+    {md5,<<"md5hash">>}]}.
+
+mock_url_report() ->
+  {ok,[
+    {scan_id, <<"mockurlreportscanid">>},
+    {resource,<<"http://www.google.com">>},
+    {url,<<"http://www.google.com/">>},
+    {response_code,1},
+    {scan_date,<<"2016-10-14 22:28:00">>},
+    {permalink,
+      <<"https://www.virustotal.com/url/dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf/analysis/1476484080/">>},
+    {verbose_msg,
+      <<"Scan finished, scan information embedded in this object">>},
+    {filescan_id,null},
+    {positives,0},
+    {total,68},
+    {scans, [
+      {'CLEAN MX',[{detected,false},{result,<<"clean site">>}]},
+      {'Rising',[{detected,false},{result,<<"clean site">>}]},
+      {'AegisLab WebGuard',[{detected,false},{result,<<"clean site">>}]},
+      {'MalwareDomainList', [
+        {detected,false},
+        {result,<<"clean site">>},
+        {detail, <<"http://www.malwaredomainlist.com/mdl.php?search=www.google.com">>}]}]}]}.

--- a/test/virustotal_client_tests.erl
+++ b/test/virustotal_client_tests.erl
@@ -60,27 +60,27 @@ results_from_file_report_cache_addition(Name) ->
   virustotal_client:file_report(Name, <<"newhash">>),
   Result = [
     {{resource, <<"newhash">>},
-      {ok,[
-      {scans,[
-        {'Bkav',[{detected,false},
-          {version,<<"1.3.0.8455">>},
-          {result,null},
-          {update,<<"20161013">>}]},
-        {'MicroWorld-eScan',[{detected,true},
-          {version,<<"12.0.250.0">>},
-          {result,<<"Generic.Malware.V!w.7232B058">>},
-          {update,<<"20161013">>}]}]},
-      {scan_id,<<"mockfilereportscanid">>},
-      {sha1,<<"sha1hash">>},
-      {resource,<<"testhash">>},
-      {response_code,1},
-      {scan_date,<<"2016-10-13 22:35:18">>},
-      {permalink,<<"https://www.virustotal.com/file/testhash">>},
-      {verbose_msg,<<"Scan finished, information embedded">>},
-      {total,56},
-      {positives,50},
-      {sha256,<<"sha256hash">>},
-      {md5,<<"md5hash">>}]}}],
+      {ok,#{
+        md5 => <<"md5hash">>,
+        permalink => <<"https://www.virustotal.com/file/testhash">>,
+        positives => 50,
+        resource => <<"testhash">>,
+        response_code => 1,
+        scan_date => <<"2016-10-13 22:35:18">>,
+        scan_id => <<"mockfilereportscanid">>,
+        scans => #{
+          'Bkav' => #{detected => false,
+            result => null,
+            update => <<"20161013">>,
+            version => <<"1.3.0.8455">>},
+          'MicroWorld-eScan' => #{detected => true,
+            result => <<"Generic.Malware.V!w.7232B058">>,
+            update => <<"20161013">>,
+            version => <<"12.0.250.0">>}},
+        sha1 => <<"sha1hash">>,
+        sha256 => <<"sha256hash">>,
+        total => 56,
+        verbose_msg => <<"Scan finished, information embedded">>}}}],
   ?_assert(Result == ets:lookup(?CACHE_NAME, {resource, <<"newhash">>})).
 
 
@@ -115,27 +115,24 @@ results_from_url_report_cache_addition(Name) ->
   virustotal_client:url_report(Name, <<"newlink">>),
   Result = [
     {{resource, <<"newlink">>},
-      {ok,[
-        {scan_id, <<"mockurlreportscanid">>},
-        {resource,<<"http://www.google.com">>},
-        {url,<<"http://www.google.com/">>},
-        {response_code,1},
-        {scan_date,<<"2016-10-14 22:28:00">>},
-        {permalink,
-          <<"https://www.virustotal.com/url/dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf/analysis/1476484080/">>},
-        {verbose_msg,
-          <<"Scan finished, scan information embedded in this object">>},
-        {filescan_id,null},
-        {positives,0},
-        {total,68},
-        {scans, [
-          {'CLEAN MX',[{detected,false},{result,<<"clean site">>}]},
-          {'Rising',[{detected,false},{result,<<"clean site">>}]},
-          {'AegisLab WebGuard',[{detected,false},{result,<<"clean site">>}]},
-          {'MalwareDomainList', [
-            {detected,false},
-            {result,<<"clean site">>},
-            {detail, <<"http://www.malwaredomainlist.com/mdl.php?search=www.google.com">>}]}]}]}}],
+      {ok,#{
+        filescan_id => null,
+        permalink => <<"https://www.virustotal.com/url/dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf/analysis/1476484080/">>,
+        positives => 0,
+        resource => <<"http://www.google.com">>,
+        response_code => 1,
+        scan_date => <<"2016-10-14 22:28:00">>,
+        scan_id => <<"mockurlreportscanid">>,
+        scans => #{
+          'AegisLab WebGuard' => #{detected => false,result => <<"clean site">>},
+          'CLEAN MX' => #{detected => false,result => <<"clean site">>},
+          'MalwareDomainList' => #{detail => <<"http://www.malwaredomainlist.com/mdl.php?search=www.google.com">>,
+            detected => false,
+            result => <<"clean site">>},
+          'Rising' => #{detected => false,result => <<"clean site">>}},
+        total => 68,
+        url => <<"http://www.google.com/">>,
+        verbose_msg => <<"Scan finished, scan information embedded in this object">>}}}],
   ?_assert(Result == ets:lookup(?CACHE_NAME, {resource, <<"newlink">>})).
 
 load_cache() ->

--- a/test/virustotal_tests.erl
+++ b/test/virustotal_tests.erl
@@ -5,13 +5,14 @@
 -define(setup(F), {setup, fun start/0, fun stop/1, F}).
 
 start() ->
-  {ok, Pid} = virustotal:start_link(foo, <<"apikey">>),
+  application:ensure_all_started(virustotal),
+  {ok, _Pid} = virustotal:start(foo, <<"apikey">>),
   meck:new(virustotal_client),
-  Pid.
+  foo.
 
-stop(_Pid) ->
+stop(Name) ->
   meck:unload(virustotal_client),
-  virustotal:stop(foo).
+  virustotal:stop(Name).
 
 file_scan_test_() ->
   [{"file_scan returns results", ?setup(fun results_from_file_scan/1)}].
@@ -28,27 +29,27 @@ sync_url_scan_test_() ->
 url_report_test_() ->
   [{"url_report returns results", ?setup(fun results_from_url_report/1)}].
 
-results_from_file_scan(_) ->
+results_from_file_scan(Name) ->
   meck:expect(virustotal_client, file_scan, fun(_Key, _Resource) -> {ok, []} end),
-  {ok, _} = virustotal:file_scan(foo, <<"somefile.zip">>),
+  {ok, _} = virustotal:file_scan(Name, <<"somefile.zip">>),
   ?_assert(meck:validate(virustotal_client)).
 
-results_from_file_report(_) ->
+results_from_file_report(Name) ->
   meck:expect(virustotal_client, file_report, fun(_Key, _Resource) -> {ok, []} end),
-  {ok, _} = virustotal:file_report(foo, <<"somefile.zip">>),
+  {ok, _} = virustotal:file_report(Name, <<"somefile.zip">>),
   ?_assert(meck:validate(virustotal_client)).
 
-ok_from_url_scan(_) ->
+ok_from_url_scan(Name) ->
   meck:expect(virustotal_client, url_scan, fun(_Key, _Resource) -> {ok, []} end),
-  ok = virustotal:url_scan(foo, <<"www.google.com">>),
+  ok = virustotal:url_scan(Name, <<"www.google.com">>),
   ?_assert(meck:validate(virustotal_client)).
 
-results_from_sync_url_scan(_) ->
+results_from_sync_url_scan(Name) ->
   meck:expect(virustotal_client, url_scan, fun(_Key, _Resource) -> {ok, []} end),
-  {ok, _} = virustotal:sync_url_scan(foo, <<"www.google.com">>),
+  {ok, _} = virustotal:sync_url_scan(Name, <<"www.google.com">>),
   ?_assert(meck:validate(virustotal_client)).
 
-results_from_url_report(_) ->
+results_from_url_report(Name) ->
   meck:expect(virustotal_client, url_report, fun(_Key, _Resource) -> {ok, []} end),
-  {ok, _} = virustotal:url_report(foo, <<"www.google.com">>),
+  {ok, _} = virustotal:url_report(Name, <<"www.google.com">>),
   ?_assert(meck:validate(virustotal_client)).


### PR DESCRIPTION
1. Implemented use of pools for connections to virus total
2. cache file_report & url_report
3. return hashes instead of proplist

# VERIFICATION
- [ ] tests should pass
- [ ] results should be a hash instead of proplist
- [ ] check ets cache to make sure calls are cached

Thanks!